### PR TITLE
make validator compatible with Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.1.2
+  - 1.8.7
 cache:
   - bundler
   - apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - 2.1.2
-  - 1.8.7
 cache:
   - bundler
   - apt

--- a/lib/usi/validator.rb
+++ b/lib/usi/validator.rb
@@ -12,7 +12,7 @@ class Usi::Validator
 
   def valid?
     if ten_valid_characters?
-      identifier[-1] == checker.generate(identifier[0..8])
+      identifier.split('').last == checker.generate(identifier[0..8])
     else
       false
     end


### PR DESCRIPTION
Ruby 1.8 provides the integer code of the character when using an array lookup on a string
