### PR TITLE
SRE-3058 Run specs with GitHub actions

### DIFF
--- a/.github/workflows/run-specs.yml
+++ b/.github/workflows/run-specs.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/run-specs.yml
+++ b/.github/workflows/run-specs.yml
@@ -1,4 +1,3 @@
-# create github action to execute ruby spec suite
 name: Run specs
 on: [push]
 jobs:

--- a/.github/workflows/run-specs.yml
+++ b/.github/workflows/run-specs.yml
@@ -1,0 +1,18 @@
+# create github action to execute ruby spec suite
+name: Run specs
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+      - name: Run specs
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-  - 2.1.2
-cache:
-  - bundler
-  - apt
-bundler_args: -j4 --quiet
-script:
-  - bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # USI
 
 [![Code Climate](https://codeclimate.com/github/jobready/usi.png)](https://codeclimate.com/github/jobready/usi)
-[![Build Status](https://travis-ci.org/jobready/usi.svg)](https://travis-ci.org/jobready/usi)
+[![Gem Downloads](https://img.shields.io/gem/dt/usi.svg)](https://rubygems.org/gems/usi)
+![specs workflow](https://github.com/rdytech/usi/actions/workflows/run-specs.yml/badge.svg)
 
 A gem for validating USI (Unique Student Identifiers) for VET Students in Australia
 
@@ -56,7 +57,7 @@ end
 
 ## Contributing
 
-1. Fork it ( http://github.com/jobready/usi/fork )
+1. Fork it ( http://github.com/rdytech/usi/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,8 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'coveralls'
-Coveralls.wear!
-
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-   Coveralls::SimpleCov::Formatter,
+  SimpleCov::Formatter::HTMLFormatter
 ]
 
 SimpleCov.configure do
@@ -17,7 +13,6 @@ require 'bundler/setup'
 Bundler.require(:default, :development)
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.filter_run_excluding perf: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,7 @@
 require 'simplecov'
 SimpleCov.start
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 
 SimpleCov.configure do
   add_filter '/spec/'

--- a/usi.gemspec
+++ b/usi.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.3.6'
 
   spec.add_development_dependency 'bundler', '> 1.0'
-  spec.add_development_dependency 'rspec', '~> 2.14'
-  spec.add_development_dependency 'cane', '~> 2.6'
-  spec.add_development_dependency 'byebug', '~> 2.7'
-  spec.add_development_dependency 'rake', '~> 10.1'
-  spec.add_development_dependency 'coveralls', '~> 0'
+  spec.add_development_dependency 'rspec', '> 2.14'
+  spec.add_development_dependency 'cane', '> 2.6'
+  spec.add_development_dependency 'byebug', '> 2.7'
+  spec.add_development_dependency 'rake', '> 10.1'
+  spec.add_development_dependency 'coveralls', '> 0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/usi.gemspec
+++ b/usi.gemspec
@@ -6,16 +6,15 @@ require 'usi/version'
 Gem::Specification.new do |spec|
   spec.name          = 'usi'
   spec.version       = Usi::VERSION
-  spec.authors       = ["John D'Agostino"]
-  spec.email         = ['john.dagostino@gmail.com']
+  spec.email         = ['engineering@readytech.io']
   spec.summary       = %q{Validate Australian Government USI}
   spec.description   = %q{A gem for validating Australian Government Unique Student Identifiers (USI)}
-  spec.homepage      = 'https://github.com/jobready/usi'
+  spec.homepage      = 'https://github.com/rdytech/usi'
   spec.license       = 'MIT'
 
   spec.required_rubygems_version = '>= 1.3.6'
 
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'bundler', '> 1.0'
   spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'cane', '~> 2.6'
   spec.add_development_dependency 'byebug', '~> 2.7'
@@ -27,4 +26,3 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 end
-

--- a/usi.gemspec
+++ b/usi.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cane', '> 2.6'
   spec.add_development_dependency 'byebug', '> 2.7'
   spec.add_development_dependency 'rake', '> 10.1'
-  spec.add_development_dependency 'coveralls', '> 0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/usi.gemspec
+++ b/usi.gemspec
@@ -6,6 +6,7 @@ require 'usi/version'
 Gem::Specification.new do |spec|
   spec.name          = 'usi'
   spec.version       = Usi::VERSION
+  spec.authors       = ['ReadyTech']
   spec.email         = ['engineering@readytech.io']
   spec.summary       = %q{Validate Australian Government USI}
   spec.description   = %q{A gem for validating Australian Government Unique Student Identifiers (USI)}

--- a/usi.gemspec
+++ b/usi.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cane', '> 2.6'
   spec.add_development_dependency 'byebug', '> 2.7'
   spec.add_development_dependency 'rake', '> 10.1'
+  spec.add_development_dependency 'simplecov', '> 0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Use GitHub actions to run the spec suite replacing the defunct Travis and Coveralls code

https://jobready.atlassian.net/browse/SRE-3058