### PR TITLE
Add Action for gem publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+
+    - name: Publish to RubyGems
+      run: |
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2] - 2023-04-14
+### Added
+- Update of gemspec to reflect organisation renaming
+- Add GitHub Actions for CI
+
+## [0.0.1] - 2014
+### Added
+- Initial gem

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,3 @@
-Copyright (c) 2014 John D'Agostino
-
 MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
Add GitHub action for publishing to RubyGems to get gem page updated. https://rubygems.org/gems/usi